### PR TITLE
Guard against missing JWT configuration

### DIFF
--- a/HelpDeskAPI/Controllers/UsersController.cs
+++ b/HelpDeskAPI/Controllers/UsersController.cs
@@ -45,7 +45,7 @@ namespace HelpDeskAPI.Controllers
 
         // POST: api/users/login
         [HttpPost("login")]
-        public IActionResult Login([FromBody] LoginRequestUser loginRequest)
+        public IActionResult Login([FromBody] LoginRequest loginRequest)
         {
             var correo = loginRequest.Correo;
             var contraseña = loginRequest.Contraseña;

--- a/HelpDeskAPI/Program.cs
+++ b/HelpDeskAPI/Program.cs
@@ -23,7 +23,13 @@ builder.Services.AddCors(options =>
 
 // 🛡️ Leer configuración del JWT desde appsettings.json
 var jwtSettings = builder.Configuration.GetSection("Jwt");
-var key = Encoding.ASCII.GetBytes(jwtSettings["Key"]);
+var keyString = jwtSettings["Key"]
+    ?? throw new InvalidOperationException("JWT Key missing in configuration");
+var issuer = jwtSettings["Issuer"]
+    ?? throw new InvalidOperationException("JWT Issuer missing in configuration");
+var audience = jwtSettings["Audience"]
+    ?? throw new InvalidOperationException("JWT Audience missing in configuration");
+var key = Encoding.ASCII.GetBytes(keyString);
 
 // 🔐 Configurar autenticación JWT
 builder.Services.AddAuthentication(options =>
@@ -41,8 +47,8 @@ builder.Services.AddAuthentication(options =>
         IssuerSigningKey = new SymmetricSecurityKey(key),
         ValidateIssuer = true,
         ValidateAudience = true,
-        ValidIssuer = jwtSettings["Issuer"],
-        ValidAudience = jwtSettings["Audience"]
+        ValidIssuer = issuer,
+        ValidAudience = audience
     };
 });
 

--- a/HelpDeskAPI/Services/AuthService.cs
+++ b/HelpDeskAPI/Services/AuthService.cs
@@ -20,7 +20,9 @@ public class AuthService
             new Claim(ClaimTypes.Role, role)
         };
 
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]));
+        var keyValue = _configuration["Jwt:Key"]
+            ?? throw new InvalidOperationException("JWT Key not configured");
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyValue));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(
@@ -34,7 +36,7 @@ public class AuthService
     }
 
     // Aquí validas el usuario, ejemplo simple (debes validar en DB)
-    public bool ValidateUser(string username, string password, out string role)
+    public bool ValidateUser(string username, string password, out string? role)
     {
         // TODO: validar en base de datos
         // Ejemplo duro:


### PR DESCRIPTION
## Summary
- Add explicit null checks for JWT key, issuer, and audience values
- Allow ValidateUser to return a nullable role
- Use `LoginRequest` model in users login endpoint

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689110a15644832984da6b6ec634303d