### PR TITLE
Fix nullability warnings and Encoding usage

### DIFF
--- a/HelpDeskAPI/Models/ChatMessage.cs
+++ b/HelpDeskAPI/Models/ChatMessage.cs
@@ -11,16 +11,16 @@ namespace HelpDeskAPI.Models
         public int TicketId { get; set; }
 
         [ForeignKey("TicketId")]
-        public Ticket Ticket { get; set; }
+        public Ticket? Ticket { get; set; }
 
         [Required]
         public int UsuarioId { get; set; }
 
         [ForeignKey("UsuarioId")]
-        public User Usuario { get; set; }
+        public User? Usuario { get; set; }
 
         [Required]
-        public string Mensaje { get; set; }
+        public string Mensaje { get; set; } = string.Empty;
 
         public DateTime Fecha { get; set; }
         public DateTime Timestamp { get; set; } = DateTime.Now;

--- a/HelpDeskAPI/Models/LoginRequest.cs
+++ b/HelpDeskAPI/Models/LoginRequest.cs
@@ -2,7 +2,7 @@ namespace HelpDeskAPI.Models
 {
     public class LoginRequest
     {
-        public string Correo { get; set; }
-        public string Contraseña { get; set; }
+        public string Correo { get; set; } = string.Empty;
+        public string Contraseña { get; set; } = string.Empty;
     }
 }

--- a/HelpDeskAPI/Models/Ticket.cs
+++ b/HelpDeskAPI/Models/Ticket.cs
@@ -8,24 +8,24 @@ namespace HelpDeskAPI.Models
         public int Id { get; set; }
 
         [Required]
-        public string Titulo { get; set; }
+        public string Titulo { get; set; } = string.Empty;
 
-        public string Descripcion { get; set; }
+        public string? Descripcion { get; set; }
 
         [Required]
         public int UsuarioId { get; set; }
 
-        public User Usuario { get; set; }
+        public User? Usuario { get; set; }
 
         public int? TecnicoId { get; set; }
 
-        public User Tecnico { get; set; }
+        public User? Tecnico { get; set; }
 
         public DateTime FechaCreacion { get; set; } = DateTime.UtcNow;
 
         public string Estado { get; set; } = "Abierto";
 
         // ✅ Relación con mensajes
-        public ICollection<ChatMessage> ChatMessages { get; set; }
+        public ICollection<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
     }
 }

--- a/HelpDeskAPI/Models/User.cs
+++ b/HelpDeskAPI/Models/User.cs
@@ -7,21 +7,21 @@ namespace HelpDeskAPI.Models
         public int Id { get; set; }
 
         [Required]
-        public string Nombre { get; set; }
+        public string Nombre { get; set; } = string.Empty;
 
         [Required]
-        public string Correo { get; set; }
+        public string Correo { get; set; } = string.Empty;
 
         [Required]
-        public string Contraseña { get; set; }
+        public string Contraseña { get; set; } = string.Empty;
 
         [Required]
-        public string Rol { get; set; } // ejemplo: "Usuario", "Técnico", "Admin"
+        public string Rol { get; set; } = string.Empty; // ejemplo: "Usuario", "Técnico", "Admin"
 
-        public ICollection<Ticket> TicketsCreados { get; set; }
+        public ICollection<Ticket> TicketsCreados { get; set; } = new List<Ticket>();
 
-        public ICollection<Ticket> TicketsAsignados { get; set; }
+        public ICollection<Ticket> TicketsAsignados { get; set; } = new List<Ticket>();
 
-        public ICollection<ChatMessage> MensajesEnviados { get; set; }
+        public ICollection<ChatMessage> MensajesEnviados { get; set; } = new List<ChatMessage>();
     }
 }

--- a/HelpDeskAPI/Program.cs
+++ b/HelpDeskAPI/Program.cs
@@ -29,7 +29,7 @@ var issuer = jwtSettings["Issuer"]
     ?? throw new InvalidOperationException("JWT Issuer missing in configuration");
 var audience = jwtSettings["Audience"]
     ?? throw new InvalidOperationException("JWT Audience missing in configuration");
-var key = Encoding.ASCII.GetBytes(keyString);
+var key = Encoding.ASCII.GetBytes(keyString ?? string.Empty);
 
 // 🔐 Configurar autenticación JWT
 builder.Services.AddAuthentication(options =>

--- a/HelpDeskAPI/Services/AuthService.cs
+++ b/HelpDeskAPI/Services/AuthService.cs
@@ -22,7 +22,7 @@ public class AuthService
 
         var keyValue = _configuration["Jwt:Key"]
             ?? throw new InvalidOperationException("JWT Key not configured");
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyValue));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyValue ?? string.Empty));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(


### PR DESCRIPTION
## Summary
- initialize non-nullable properties in User, Ticket, ChatMessage and LoginRequest models
- allow optional navigation properties and collections with safe defaults
- guard Encoding.GetBytes calls with null-coalescing to avoid warnings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891266c165c83298584a2944669629e