### PR TITLE
Enable ticket assignment and resolution workflow

### DIFF
--- a/HelpDeskAPI/Controllers/TicketsController.cs
+++ b/HelpDeskAPI/Controllers/TicketsController.cs
@@ -108,5 +108,52 @@ namespace HelpDeskAPI.Controllers
 
             return NoContent();
         }
+
+        // PUT: api/tickets/{id}/assign
+        [HttpPut("{id}/assign")]
+        public async Task<IActionResult> AssignTicket(int id, [FromBody] AssignTicketRequest request)
+        {
+            var ticket = await _context.Tickets.FindAsync(id);
+            if (ticket == null)
+            {
+                return NotFound();
+            }
+
+            ticket.TecnicoId = request.TecnicoId;
+            ticket.Estado = "Asignado";
+
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        // PUT: api/tickets/{id}/status
+        [HttpPut("{id}/status")]
+        public async Task<IActionResult> UpdateStatus(int id, [FromBody] UpdateTicketStatusRequest request)
+        {
+            var ticket = await _context.Tickets.FindAsync(id);
+            if (ticket == null)
+            {
+                return NotFound();
+            }
+
+            ticket.Estado = request.Estado;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        // POST: api/tickets/{id}/resolve
+        [HttpPost("{id}/resolve")]
+        public async Task<IActionResult> ResolveTicket(int id)
+        {
+            var ticket = await _context.Tickets.FindAsync(id);
+            if (ticket == null)
+            {
+                return NotFound();
+            }
+
+            _context.Tickets.Remove(ticket);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
     }
 }

--- a/HelpDeskAPI/Models/AssignTicketRequest.cs
+++ b/HelpDeskAPI/Models/AssignTicketRequest.cs
@@ -1,0 +1,7 @@
+namespace HelpDeskAPI.Models
+{
+    public class AssignTicketRequest
+    {
+        public int TecnicoId { get; set; }
+    }
+}

--- a/HelpDeskAPI/Models/UpdateTicketStatusRequest.cs
+++ b/HelpDeskAPI/Models/UpdateTicketStatusRequest.cs
@@ -1,0 +1,7 @@
+namespace HelpDeskAPI.Models
+{
+    public class UpdateTicketStatusRequest
+    {
+        public string Estado { get; set; } = string.Empty;
+    }
+}

--- a/helpdesk-frontend/src/components/TicketList.js
+++ b/helpdesk-frontend/src/components/TicketList.js
@@ -1,14 +1,31 @@
 import React from 'react';
 
+const API_URL = 'http://localhost:5131/api';
+
 function TicketList({ tickets = [] }) {
-  const handleAssign = (ticketId) => {
-    // TODO: Implement assignment logic (API call)
-    alert(`Assign ticket ${ticketId} to a technician`);
+  const handleAssign = async (ticketId) => {
+    const tecnicoId = prompt('Ingrese el ID del técnico:');
+    if (!tecnicoId) return;
+    await fetch(`${API_URL}/tickets/${ticketId}/assign`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tecnicoId: Number(tecnicoId) })
+    });
+    alert(`Ticket ${ticketId} asignado al técnico ${tecnicoId}`);
   };
 
-  const handleStatusChange = (ticketId, newStatus) => {
-    // TODO: Implement status update logic (API call)
-    alert(`Change status of ticket ${ticketId} to ${newStatus}`);
+  const handleStatusChange = async (ticketId, newStatus) => {
+    if (newStatus === 'Cerrado') {
+      await fetch(`${API_URL}/tickets/${ticketId}/resolve`, { method: 'POST' });
+      alert(`Ticket ${ticketId} resuelto y eliminado`);
+    } else {
+      await fetch(`${API_URL}/tickets/${ticketId}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ estado: newStatus })
+      });
+      alert(`Estado del ticket ${ticketId} actualizado a ${newStatus}`);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- allow assigning tickets to technicians via new API
- support ticket status updates and resolving which removes the ticket
- integrate frontend ticket list with assignment and resolve endpoints

## Testing
- `npm test --prefix helpdesk-frontend -- --watchAll=false`
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68916ac1a1e4832999d8130df2ea182f